### PR TITLE
Add migration

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.0.2
+:Version: 1.0.3
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 |build-status| |coverage| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 1.0.1
+:Version: 1.0.2
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat

--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from collections import namedtuple
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'https://github.com/celery/django-celery-beat'

--- a/django_celery_beat/__init__.py
+++ b/django_celery_beat/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from collections import namedtuple
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'https://github.com/celery/django-celery-beat'

--- a/django_celery_beat/migrations/0004_auto_20170221_0000.py
+++ b/django_celery_beat/migrations/0004_auto_20170221_0000.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_celery_beat', '0003_auto_20161209_0049'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='solarschedule',
+            name='longitude',
+            field=models.DecimalField(verbose_name='longitude', max_digits=9, decimal_places=6),
+        ),
+    ]

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 1.0.1
+:Version: 1.0.2
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 1.0.2
+:Version: 1.0.3
 :Web: http://django-celery-beat.readthedocs.io/
 :Download: http://pypi.python.org/pypi/django-celery-beat
 :Source: http://github.com/celery/django-celery-beat


### PR DESCRIPTION
For @yorinasub17 this adds the missing migration to django-celery-beat and also bumps the version to 1.0.3 so that we make sure to install the most up to date code when this is released